### PR TITLE
feat: add Buffer method for convenient io.Reader/io.Writer usage

### DIFF
--- a/json.go
+++ b/json.go
@@ -1,6 +1,9 @@
 package nine
 
-import "encoding/json"
+import (
+	"bytes"
+	"encoding/json"
+)
 
 // JSON represents a map of strings to arbitrary values,
 // facilitating the manipulation of JSON data in map format.
@@ -10,6 +13,30 @@ type JSON map[string]interface{}
 // It returns a slice of bytes containing the JSON representation and an error, if any.
 func (j JSON) Bytes() ([]byte, error) {
 	return json.Marshal(j)
+}
+
+// Buffer converts the JSON into a bytes.Buffer pointer using JSON encoding.
+// It returns a pointer to a bytes.Buffer containing the JSON representation
+// of the map, and an error if any occurs during encoding.
+//
+// This method is useful when you need a buffer instead of a byte slice,
+// such as when working with I/O operations.
+//
+// Example:
+//
+//		data := nine.JSON{"name": "John", "age": 30}
+//		buf, err := data.Buffer()
+//		if err != nil {
+//			// Handle the error
+//		}
+//		// Use the buffer as needed
+//
+func (j JSON) Buffer() (*bytes.Buffer, error) {
+	b, err := j.Bytes()
+	if err != nil {
+		return nil, err
+	}
+	return bytes.NewBuffer(b), nil
 }
 
 // DecodeJSON decodes a byte slice containing JSON data into a value of type V.

--- a/json_test.go
+++ b/json_test.go
@@ -2,28 +2,48 @@ package nine
 
 import (
 	"fmt"
+	"io"
 	"testing"
 )
 
 func TestJSON(t *testing.T) {
 	username := "gabrielluizsf"
 	json := JSON{"username": username}
+	
 	b, err := json.Bytes()
 	if err != nil {
 		t.Fatal(err)
 	}
+	
 	result := string(b)
 	expected := fmt.Sprintf(`{"username":"%s"}`, username)
+	
 	if result != expected {
 		t.Fatalf("result: %s expected: %s", result, expected)
 	}
+	
 	var user struct {
 		Username string `json:"username"`
 	}
+	
 	if err := DecodeJSON(b, &user); err != nil {
 		t.Fatal(err)
 	}
+	
 	if user.Username != username {
 		t.Fatal("user not decoded")
+	}
+	
+	buf, err := json.Buffer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	if _, ok := any(buf).(io.Reader); !ok {
+		t.Fatal("buf does not implement io.Reader")
+	}
+
+	if _, ok := any(buf).(io.Writer); !ok {
+		t.Fatal("buf does not implement io.Writer")
 	}
 }


### PR DESCRIPTION
Introduced the `Buffer` method to the `JSON` type, which converts the JSON map into a `bytes.Buffer`. This enhancement facilitates the use of JSON data with interfaces requiring `io.Reader` or `io.Writer`, making it easier to integrate JSON handling with I/O operations.