### PR TITLE
test: adding unit test for ServeFiles handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ go.work.sum
 
 # env file
 .env
+
+# coverage files directory
+coverage

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,6 @@
 test:
 	go test --race -cover
+
+COVERAGE_DIR="coverage"
+coverage:
+	@go test -coverprofile=./$(COVERAGE_DIR)/coverage.out ./... && mkdir -p $(COVERAGE_DIR) && go tool cover -html=./$(COVERAGE_DIR)/coverage.out -o $(COVERAGE_DIR)/index.html


### PR DESCRIPTION
- Added unit tests to cover the ServeFiles handler functionality.
- Enhanced test coverage with new HTML report generation command.
- Updated .gitignore to exclude coverage files directory.
- Refactored TestUse to include additional routes and generalize header verification.
