### PR TITLE
refactor: separate port and address in Server struct for flexibility

### DIFF
--- a/server.go
+++ b/server.go
@@ -155,16 +155,16 @@ type Server struct {
 	mux               *http.ServeMux
 	routes            []Router
 	globalMiddlewares []Handler
-	addr              string
+	addr, port        string
 }
 
 // NewServer creates a new `Server` instance bound to the specified port.
 // It accepts both integer and string types for the port.
 func NewServer[P int | string](port P) *Server {
 	return &Server{
-		addr:   fmt.Sprintf(":%v", port),
 		mux:    http.NewServeMux(),
 		routes: make([]Router, 0),
+		port:   fmt.Sprint(port),
 	}
 }
 
@@ -252,7 +252,15 @@ func (s *Server) Delete(endpoint string, handlers ...Handler) error {
 //	log.Fatal(server.Listen())
 func (s *Server) Listen() error {
 	s.registerRoutes()
+	s.setAddr()
 	return http.ListenAndServe(s.addr, s.mux)
+}
+
+func (s *Server) setAddr() {
+	if len(s.port) == 0 {
+		s.addr = ":0"
+	}
+	s.addr = fmt.Sprintf(":%s", s.port)
 }
 
 func (s *Server) registerRoutes() {

--- a/server.go
+++ b/server.go
@@ -259,6 +259,7 @@ func (s *Server) Listen() error {
 func (s *Server) setAddr() {
 	if len(s.port) == 0 {
 		s.addr = ":0"
+		return
 	}
 	s.addr = fmt.Sprintf(":%s", s.port)
 }

--- a/server_test.go
+++ b/server_test.go
@@ -186,6 +186,22 @@ func TestServeFiles(t *testing.T) {
 	}
 }
 
+func TestSetAddr(t *testing.T) {
+	port := "7080"
+	server := NewServer(port)
+	server.setAddr()
+	expected := ":" + port
+	if server.addr != expected {
+		t.Fatalf("result %s, expected %s", server.addr, expected)
+	}
+	server = NewServer("")
+	server.setAddr()
+	expected = ":0"
+	if server.addr != expected {
+		t.Fatalf("result %s, expected %s", server.addr, expected)
+	}
+}
+
 func TestUse(t *testing.T) {
 	message := "new request received"
 	server := NewServer(5050)


### PR DESCRIPTION
- Added `port` field to `Server` struct to store the port separately from `addr`.
- Modified `NewServer` to initialize the `port` field instead of setting `addr` directly.
- Introduced `setAddr` method to handle address formatting based on port, with a fallback to port `0` if unspecified.
- Improved readability and separation of concerns by distinguishing port from the full address.