### PR TITLE
feat: enhance route registration with path transformation

### DIFF
--- a/server.go
+++ b/server.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 )
 
 type Request struct {
@@ -280,12 +281,17 @@ func (s *Server) registerRoute(method, endpoint string, handlers ...Handler) err
 	handler := handlers[len(handlers)-1]
 
 	r := Router{
-		pattern:     fmt.Sprintf("%s %s", method, endpoint),
+		pattern:     fmt.Sprintf("%s %s", method, s.transformPath(endpoint)),
 		handler:     handler,
 		middlewares: handlers[:len(handlers)-1],
 	}
 	s.routes = append(s.routes, r)
 	return nil
+}
+
+func (s *Server) transformPath(path string) string {
+	re := regexp.MustCompile(`:(\w+)`)
+	return re.ReplaceAllString(path, "{$1}")
 }
 
 func registerMiddlewares(handler http.Handler, middlewares ...Handler) http.Handler {

--- a/server_test.go
+++ b/server_test.go
@@ -202,6 +202,20 @@ func TestSetAddr(t *testing.T) {
 	}
 }
 
+func TestTransformPath(t *testing.T){
+	expected := "/user/{id}/messages/{name}"
+	server := NewServer(8413)
+	result := server.transformPath("/user/:id/messages/:name")
+	if result != expected{
+		t.Fatalf("result %s, expected %s", result, expected)
+	}
+	expected = "/post/{postId}/{comment}/{commentId}/{username}"
+	result = server.transformPath("/post/{postId}/:comment/{commentId}/:username")
+	if result != expected{
+		t.Fatalf("result %s, expected %s", result, expected)
+	}
+}
+
 func TestUse(t *testing.T) {
 	message := "new request received"
 	server := NewServer(5050)


### PR DESCRIPTION
- Updated registerRoute to transform endpoint paths, converting
  parameter placeholders (e.g., :param) into a consistent format
  (e.g., {param}) for better route matching and readability.
- Introduced transformPath method to handle the regex replacement.
- Improves code maintainability and aligns with routing standards.
- Implemented TestTransformPath to verify correct transformation
  of path parameters from colon (:) to braces ({}) format.
- Ensured that various input patterns are accurately converted,
  improving confidence in route handling functionality.