### PR TITLE
feat: Introducing a new ServerHandler struct to encapsulate HTTP handler functionality.

### DIFF
--- a/request_test.go
+++ b/request_test.go
@@ -29,7 +29,10 @@ func TestRequest(t *testing.T) {
 			expectedBody: "GET request",
 			headers:      []Header{{Data: Data{Key: "X-Custom-Header", Value: "value"}}},
 			body:         nil,
-			queryParams:  []QueryParam{{Data: Data{Key: "query", Value: "param"}}},
+			queryParams: []QueryParam{
+				{Data: Data{Key: "query", Value: "param"}},
+				{Data: Data{Key: "search", Value: "gopher"}},
+			},
 		},
 		{
 			method:       http.MethodPost,
@@ -51,9 +54,12 @@ func TestRequest(t *testing.T) {
 			method:       http.MethodPatch,
 			url:          server.URL + "/patch",
 			expectedBody: "PATCH request",
-			headers:      []Header{{Data: Data{Key: "X-Custom-Header", Value: "value"}}},
-			body:         nil,
-			queryParams:  nil,
+			headers: []Header{
+				{Data: Data{Key: "X-Custom-Header", Value: "value"}},
+				{Data: Data{Key: "X-Request-Id", Value: 101209320192}},
+			},
+			body:        nil,
+			queryParams: nil,
 		},
 		{
 			method:       http.MethodDelete,


### PR DESCRIPTION
Example of usage:

```go
package main

import (
	"fmt"
	"net/http"
	"os"

	"github.com/i9si-sistemas/nine"
)

func main() {
	server := nine.NewServer(os.Getenv("PORT"))
	server.Get("/", func(req *nine.Request, res *nine.Response) error {
		return res.Send([]byte("Hello World"))
	})
	handler := server.Handler()
	addr := fmt.Sprintf(":%s", server.Port())
	http.ListenAndServe(addr, handler)
}

```