### PR TITLE
feat: adding a notFoundMiddleware to handle 404 errors when a route is not found.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/i9si-sistemas/nine
 
-go 1.22.5
+go 1.23.1
+
+toolchain go1.23.2
+
+require github.com/i9si-sistemas/assert v0.0.0-20241009185655-c32c80e1bc67

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/i9si-sistemas/assert v0.0.0-20241009185655-c32c80e1bc67 h1:kKienFejW2g1KoBM/2HTqcv6Xzp4kIQdSuGWOZ/3yoE=
+github.com/i9si-sistemas/assert v0.0.0-20241009185655-c32c80e1bc67/go.mod h1:xRwY4u6NZZjNLlgdBSaNESQEUSJ4CxuT4lWQAbvwfBQ=

--- a/routes.go
+++ b/routes.go
@@ -1,0 +1,15 @@
+package nine
+
+type Routes []Router
+
+func (r Routes) Len() int {
+	return len(r)
+}
+
+func (r Routes) Less(i, j int) bool {
+	return r[i].pattern < r[j].pattern
+}
+
+func (r Routes) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+}

--- a/routes_test.go
+++ b/routes_test.go
@@ -1,0 +1,45 @@
+package nine
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/i9si-sistemas/assert"
+)
+
+func TestRoutes(t *testing.T) {
+	r := make(Routes, 0)
+	if r.Len() != len(r) {
+		t.FailNow()
+	}
+	r = append(r, Router{pattern: "/"})
+	r = append(r, Router{pattern: "/user/{id}"})
+	r = append(r, Router{pattern: "/user"})
+	sort.Sort(r)
+	expected := Routes{{pattern: "/"}, {pattern: "/user"}, {pattern: "/user/{id}"}}
+	assert.Equal(t, r, expected, "should be equal")
+
+	server := NewServer(42)
+
+	payload := JSON{
+		"user": JSON{
+			"id":   1,
+			"name": "gabrielluizsf",
+		},
+	}
+	server.Get("/user", func(req *Request, res *Response) error {
+		return res.JSON(payload)
+	})
+	req := httptest.NewRequest(http.MethodGet, "/user", nil)
+	w := server.Test().Request(req)
+	assert.Equal(t, w.Code, 200, "status code should be 200")
+	responseBytes := w.Body.Bytes()
+	b, err := payload.Bytes()
+	assert.NoError(t, err, "expected no error")
+	assert.Equal(t, responseBytes[:len(responseBytes)-1], b, "should be equal bytes")
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	w = server.Test().Request(req)
+	assert.Equal(t, w.Code, 404, "status should be 404")
+}


### PR DESCRIPTION
- Enhanced the `patternExists` method to utilize binary search for improved efficiency in route pattern matching.
- Updated the `registerRoutes` method to include the new not found middleware for all route handlers.
- Introduced sorting for routes using the `Routes` type to ensure proper order for binary search.
- go get github.com/i9si-sistemas/assert
## test: adding unit tests for route handling and middleware functionality

- Created a test case in `TestRoutes` to validate the correct sorting of routes based on patterns.
- Added assertions to confirm that the expected route patterns are equivalent to the actual sorted routes.
- Implemented tests for the HTTP GET method to ensure it correctly responds with a 200 status code and the expected JSON payload when accessing the `/user` endpoint.
- Included a verification for the 404 status code when accessing an unspecified route (`/`), ensuring the `notFoundMiddleware` functions correctly.