### PR TITLE
feat: add route grouping with shared base paths and middleware

### DIFF
--- a/route_group.go
+++ b/route_group.go
@@ -1,0 +1,121 @@
+package nine
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Group creates a new route group with a base path and optional middleware.
+// All routes registered within this group will have the base path prepended
+// and the middleware applied.
+func (s *Server) Group(basePath string, middlewares ...Handler) *RouteGroup {
+	return &RouteGroup{
+		server:      s,
+		basePath:    basePath,
+		middlewares: middlewares,
+	}
+}
+
+// RouteGroup represents a group of routes that share a common base path
+// and middleware stack
+type RouteGroup struct {
+	server      *Server
+	basePath    string
+	middlewares []Handler
+}
+
+// Route accepts a base path and a function to define routes within the group.
+// All routes defined within the function will be prefixed with the group's base path
+// and the provided base path.
+func (s *Server) Route(basePath string, fn func(router *RouteGroup)) {
+	group := s.Group(basePath)
+	fn(group)
+}
+
+// Get registers a GET route within the group
+func (g *RouteGroup) Get(path string, handlers ...any) error {
+	handler, middlewares, err := registerHandlers(handlers...)
+	if err != nil {
+		return err
+	}
+	allMiddlewares := append(g.middlewares, middlewares...)
+	r := Router{
+		pattern:     g.server.routePattern(http.MethodGet, g.fullPath(path)),
+		handler:     handler,
+		middlewares: allMiddlewares,
+	}
+	return g.server.registerRoute(r)
+}
+
+// Post registers a POST route within the group
+func (g *RouteGroup) Post(path string, handlers ...any) error {
+	handler, middlewares, err := registerHandlers(handlers...)
+	if err != nil {
+		return err
+	}
+	allMiddlewares := append(g.middlewares, middlewares...)
+	r := Router{
+		pattern:     g.server.routePattern(http.MethodPost, g.fullPath(path)),
+		handler:     handler,
+		middlewares: allMiddlewares,
+	}
+	return g.server.registerRoute(r)
+}
+
+// Put registers a PUT route within the group
+func (g *RouteGroup) Put(path string, handlers ...any) error {
+	handler, middlewares, err := registerHandlers(handlers...)
+	if err != nil {
+		return err
+	}
+	allMiddlewares := append(g.middlewares, middlewares...)
+	r := Router{
+		pattern:     g.server.routePattern(http.MethodPut, g.fullPath(path)),
+		handler:     handler,
+		middlewares: allMiddlewares,
+	}
+	return g.server.registerRoute(r)
+}
+
+// Patch registers a PATCH route within the group
+func (g *RouteGroup) Patch(path string, handlers ...any) error {
+	handler, middlewares, err := registerHandlers(handlers...)
+	if err != nil {
+		return err
+	}
+	allMiddlewares := append(g.middlewares, middlewares...)
+	r := Router{
+		pattern:     g.server.routePattern(http.MethodPatch, g.fullPath(path)),
+		handler:     handler,
+		middlewares: allMiddlewares,
+	}
+	return g.server.registerRoute(r)
+}
+
+// Delete registers a DELETE route within the group
+func (g *RouteGroup) Delete(path string, handlers ...any) error {
+	handler, middlewares, err := registerHandlers(handlers...)
+	if err != nil {
+		return err
+	}
+	allMiddlewares := append(g.middlewares, middlewares...)
+	r := Router{
+		pattern:     g.server.routePattern(http.MethodDelete, g.fullPath(path)),
+		handler:     handler,
+		middlewares: allMiddlewares,
+	}
+	return g.server.registerRoute(r)
+}
+
+// fullPath combines the group's base path with the provided path
+func (g *RouteGroup) fullPath(path string) string {
+	if path == "/" {
+		return g.basePath
+	}
+	fullPath := g.basePath
+	if !strings.HasSuffix(fullPath, "/") {
+		fullPath += "/"
+	}
+	path = strings.TrimPrefix(path, "/")
+	return fullPath + path
+}

--- a/route_group_test.go
+++ b/route_group_test.go
@@ -1,0 +1,137 @@
+package nine
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/i9si-sistemas/assert"
+)
+
+func TestRouteGroup(t *testing.T) {
+	testServer := NewServer(8080)
+	type Account struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}
+	accounts := make(GenericJSON[string, Account], 0)
+	testServer.Route("/account", func(router *RouteGroup) {
+		router.Post("/create", func(c *Context) error {
+			var body Account
+			if err := Body(c.Request, &body); err != nil {
+				return c.Status(http.StatusBadRequest).JSON(JSON{
+					"message": "invalid body",
+				})
+			}
+			_, ok := accounts[body.Name]
+			response := JSON{"created": !ok}
+			if !ok {
+				accounts[body.Name] = body
+				return c.Status(http.StatusCreated).JSON(response)
+			}
+			return c.JSON(response)
+		})
+		router.Get("/:name", func(c *Context) error {
+			acc, ok := accounts[c.Param("name")]
+			if !ok {
+				return c.SendStatus(http.StatusNotFound)
+			}
+			return c.JSON(JSON{
+				"account": acc,
+			})
+		})
+	})
+	assertGroupEndpoints(t, testServer)
+	req := httptest.NewRequest(http.MethodGet, "/account/Gabriel%20Luiz", nil)
+	w := testServer.Test().Request(req)
+	assert.Equal(t, w.Result().StatusCode, http.StatusOK)
+	b := w.Body.Bytes()
+	var account struct {
+		Account `json:"account"`
+	}
+	err := DecodeJSON(b, &account)
+	assert.NoError(t, err)
+	assert.Equal(t, account.Name, "Gabriel Luiz")
+	assert.Equal(t, account.Age, 23)
+}
+
+func TestGroup(t *testing.T) {
+	testServer := NewServer(5024)
+	type Account struct {
+		Name  string `json:"name"`
+		Age   int    `json:"age"`
+		Money int64  `json:"money"`
+	}
+	accounts := make(GenericJSON[string, Account], 0)
+	accountGroup := testServer.Group("/account")
+	accountGroup.Post("/create", func(c *Context) error {
+		var body Account
+		if err := Body(c.Request, &body); err != nil {
+			return c.Status(http.StatusBadRequest).JSON(JSON{
+				"message": "invalid body",
+			})
+		}
+		_, ok := accounts[body.Name]
+		response := JSON{"created": !ok}
+		if !ok {
+			accounts[body.Name] = body
+			return c.Status(http.StatusCreated).JSON(response)
+		}
+		return c.JSON(response)
+	})
+	accountGroup.Get("/:name", func(c *Context) error {
+		acc, ok := accounts[c.Param("name")]
+		if !ok {
+			return c.SendStatus(http.StatusNotFound)
+		}
+		return c.JSON(JSON{
+			"account": acc,
+		})
+	})
+	assertGroupEndpoints(t, testServer)
+	req := httptest.NewRequest(http.MethodGet, "/account/Gabriel%20Luiz", nil)
+	w := testServer.Test().Request(req)
+	assert.Equal(t, w.Result().StatusCode, http.StatusOK)
+	b := w.Body.Bytes()
+	var account struct {
+		Account `json:"account"`
+	}
+	err := DecodeJSON(b, &account)
+	assert.NoError(t, err)
+	assert.Equal(t, account.Name, "Gabriel Luiz")
+	assert.Equal(t, account.Age, 23)
+	assert.Equal(t, account.Money, int64(5000))
+}
+
+func assertGroupEndpoints(t assert.T,testServer *Server) {
+	var response struct {
+		Created bool `json:"created"`
+	}
+	payload, err := JSON{
+		"name": "Gabriel Luiz",
+		"age":  23,
+		"money": 5000,
+	}.Buffer()
+	assert.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/account/create", payload)
+	w := testServer.Test().Request(req)
+	assert.Equal(t, w.Result().StatusCode, http.StatusCreated)
+	b := w.Body.Bytes()
+	err = DecodeJSON(b, &response)
+	assert.NoError(t, err)
+	assert.True(t, response.Created)
+
+	payload, err = JSON{
+		"name": "Gabriel Luiz",
+		"age":  23,
+		"money": 5000000,
+	}.Buffer()
+	assert.NoError(t, err)
+	req = httptest.NewRequest(http.MethodPost, "/account/create", payload)
+	w = testServer.Test().Request(req)
+	assert.Equal(t, w.Result().StatusCode, http.StatusOK)
+	b = w.Body.Bytes()
+	err = DecodeJSON(b, &response)
+	assert.NoError(t, err)
+	assert.False(t, response.Created)
+}


### PR DESCRIPTION
# Usage

````go
server := nine.NewServer(os.Getenv("PORT"))
server.Route("/billing", func(router *nine.RouteGroup) error {
          router.Get("/credits", func (c *nine.Context) error {
                    return c.JSON(nine.JSON{"credits": 5000})
           })
})
accountGroup := server.Group("/account", authMiddleware)
accountGroup.Get("/:name", func (c *nine.Context) error {
     return c.JSON(nine.JSON{"account": c.Param("name")})
})
````