### PR TITLE
refactor(server): introduce Server interface

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -33,7 +33,7 @@ type Router struct {
 	servingFiles bool
 }
 
-// NewServer creates a new `Server` instance bound to the specified port.
+// New creates a new `Server` instance bound to the specified port.
 // It accepts both integer and string types for the port.
 func New[P int | string](port P) *Server {
 	return &Server{

--- a/server.go
+++ b/server.go
@@ -1,7 +1,29 @@
 package nine
 
-import "github.com/i9si-sistemas/nine/pkg/server"
+import (
+	"context"
 
-func NewServer[T string | int](port T) *server.Server {
+	"github.com/i9si-sistemas/nine/pkg/server"
+)
+
+// Server is a high-level abstraction for creating and managing HTTP servers using nine.
+type Server interface {
+	Use(middlewares any) error
+	Get(string, ...any) error
+	Post(string, ...any) error
+	Put(string, ...any) error
+	Patch(string, ...any) error
+	Delete(string, ...any) error
+	Route(string, func(*server.RouteGroup))
+	Group(string, ...any) *server.RouteGroup
+	ServeFiles(string, string)
+	Test() *server.TestServer
+	Listen() error
+	Shutdown(ctx context.Context) error
+}
+
+// NewServer returns a new (server.Server) instance bound to the specified port.
+// It accepts both integer and string types for the port.
+func NewServer[T string | int](port T) Server {
 	return server.New(port)
 }


### PR DESCRIPTION
This PR introduces a `Server` interface to abstract HTTP server operations, improving flexibility and testability across the codebase. The `NewServer` function now returns this interface instead of a concrete type, aligning with Go best practices for interface-driven design.

- The change simplifies imports and enhances encapsulation by exposing only the interface to consumers.