### PR TITLE
feat: add merge_group trigger to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
 
 jobs:
   test:


### PR DESCRIPTION
This PR adds the `merge_group` trigger to the CI workflow. This will trigger the CI pipeline when a merge group is created, ensuring that changes are tested before they are merged into the main branch.