### PR TITLE
feat: add nine client e2e test

### DIFF
--- a/__test__/nine_client_test.go
+++ b/__test__/nine_client_test.go
@@ -1,0 +1,40 @@
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/i9si-sistemas/assert"
+	"github.com/i9si-sistemas/nine"
+	i9Client "github.com/i9si-sistemas/nine/pkg/client"
+	i9Server "github.com/i9si-sistemas/nine/pkg/server"
+)
+
+func TestNineClient(t *testing.T) {
+	server := nine.NewServer("")
+	server.Get("/", func(c *i9Server.Context) error {
+		return c.Send([]byte("Hello World!"))
+	})
+
+	go func() {
+		assert.NoError(t, server.Listen())
+	}()
+
+	time.Sleep(5 * time.Millisecond)
+
+	client := nine.New(context.Background())
+	url := fmt.Sprintf("http://localhost:%s", server.Port())
+
+	res, err := client.Get(url, &i9Client.Options{})
+	assert.NoError(t, err)
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, string(body), "Hello World!")
+	assert.Equal(t, res.StatusCode, http.StatusOK)
+}

--- a/pkg/server/route_group.go
+++ b/pkg/server/route_group.go
@@ -26,6 +26,7 @@ type RouteManager interface {
 	Test() *TestServer
 	Listen() error
 	Shutdown(ctx context.Context) error
+	Port() string
 }
 
 // RouteGroup represents a group of routes that share a common base path


### PR DESCRIPTION
This commit introduces an end-to-end test for the nine client and updates the RouteManager interface.

- Added a new e2e test file `__test__/nine_client_test.go` to verify the basic functionality of the nine client.
- Added the `Port()` method to the `RouteManager` interface to allow access to the server's port.