### PR TITLE
test: skip nine client test if httpbin.org is unavailable

### DIFF
--- a/__test__/nine_client_test.go
+++ b/__test__/nine_client_test.go
@@ -14,6 +14,9 @@ import (
 func TestNineClient(t *testing.T) {
 	client := nine.New(context.Background())
 	res, err := client.Get("https://httpbin.org/get", new(i9.Options))
+	if res.StatusCode >= 400 {
+		t.Skip("httpbin.org is not available")
+	}
 	assert.NoError(t, err)
 	defer res.Body.Close()
 


### PR DESCRIPTION
This PR adds a check to skip the `TestNineClient` test if the `httpbin.org` service is unavailable (returns a status code >= 400). This prevents the test from failing when the external service is down.