### PR TITLE
feat: add Port method to ServerManager interface

### DIFF
--- a/pkg/server/manager.go
+++ b/pkg/server/manager.go
@@ -103,4 +103,6 @@ type ServerManager interface {
 	Shutdown(ctx context.Context) error
 	// Test returns a test server for testing purposes.
 	Test() *TestServer
+	// Port returns the port the server is listening on.
+	Port() string
 }

--- a/spy/spy_server.go
+++ b/spy/spy_server.go
@@ -216,6 +216,10 @@ func (s *Server) ListenTLS(certFile, keyFile string) error {
 	return nil
 }
 
+func (s *Server) Port() (port string) {
+	return 
+}
+
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
This PR adds the `Port` method to the `ServerManager` interface. This method allows access to the port the server is listening on.