### PR TITLE
fix: remove redundant addr assignment in setAddr

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -271,8 +271,6 @@ func (s *Server) setAddr() error {
 			return err
 		}
 		s.port = port
-		s.addr = fmt.Sprintf(":%s", port)
-		return nil
 	}
 	s.addr = fmt.Sprintf(":%s", s.port)
 	return nil


### PR DESCRIPTION
The `setAddr` method was assigning the address twice, once when a new port was assigned and again unconditionally. This commit removes the redundant assignment within the `if` block to avoid potential inconsistencies.