### PR TITLE
fix: transform path regex

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -313,8 +313,13 @@ func (s *Server) routePattern(method, path string) string {
 }
 
 func (s *Server) transformPath(path string) string {
-	re := regexp.MustCompile(`:(\w+)`)
-	return re.ReplaceAllString(path, "{$1}")
+	reParam := regexp.MustCompile(`:(\w+)`)
+	reSlash := regexp.MustCompile(`/+`)
+
+	path = reParam.ReplaceAllString(path, `{$1}`)
+	path = reSlash.ReplaceAllString(path, `/`)
+
+	return path
 }
 
 // Get registers a route for handling GET requests at the specified endpoint.

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -408,6 +408,9 @@ func TestTransformPath(t *testing.T) {
 	if result != expected {
 		t.Fatalf("result %s, expected %s", result, expected)
 	}
+	result = server.transformPath("/user/:id/posts//:name")
+	expected = "/user/{id}/posts/{name}"
+	assert.Equal(t, result, expected)
 }
 
 func TestTestServer(t *testing.T) {


### PR DESCRIPTION
The transformPath function now replaces multiple consecutive forward slashes with a single forward slash. This ensures that the transformed path is properly formatted, even if the original path contains multiple consecutive forward slashes. Added a test case to verify this behavior.

- Issue:

```sh
panic: parsing "POST /v1/whatsapp/qrcode/internal/chat/shop/{id}/customers//{id}/sale/cancel": at offset 5: non-CONNECT pattern with unclean path can never match

goroutine 34 [running]:
net/http.(*ServeMux).register(...)
```